### PR TITLE
Support for multiarch linux distros

### DIFF
--- a/libraries/Runtime/BridJ/src/main/java/org/bridj/BridJ.java
+++ b/libraries/Runtime/BridJ/src/main/java/org/bridj/BridJ.java
@@ -426,6 +426,35 @@ public class BridJ {
 				paths.add("/usr/lib");
 				paths.add("/usr/local/lib");
 			}
+
+            if (Platform.isLinux() || Platform.isSolaris()) {
+                // Linux uses /usr/lib32, solaris uses /usr/lib/32
+                String archPath = (Platform.isSolaris() ? "/" : "") + (Platform.is64Bits() ? "64" : "32");
+                paths.add("/usr/lib" + archPath);
+                paths.add("/lib" + archPath);
+            }
+
+            if (Platform.isLinux()) {
+                // fix for Ubuntu 11.04+ and other multiarch distros
+                // ported from JNAs NativeLibrary.java
+                // shouldn't break anything for other distros
+                String cpu = "";
+                String kernel = "linux";
+                String libc = "gnu";
+
+                if (Platform.isIntel()) {
+                    cpu = (Platform.is64Bits() ? "x86_64" : "i386");
+                } else if (Platform.isPPC()) {
+                    cpu = (Platform.is64Bits() ? "powerpc64" : "powerpc");
+                } else if (Platform.isArm()) {
+                    cpu = "arm";
+                    libc = "gnueabi";
+                }
+
+                String multiArchPath = cpu + "-" + kernel + "-" + libc;
+                paths.add("/lib/" + multiArchPath);
+                paths.add("/usr/lib/" + multiArchPath);
+            }
         }
         return paths;
     }

--- a/libraries/Runtime/BridJ/src/main/java/org/bridj/Platform.java
+++ b/libraries/Runtime/BridJ/src/main/java/org/bridj/Platform.java
@@ -175,6 +175,17 @@ public class Platform {
     		String arch = getArch();
         return arch.equals("x86_64");
     }
+    public static boolean isIntel() {
+        String arch = getArch().toLowerCase().trim();
+        return "i386".equals(arch) ||
+                "x86_64".equals(arch) ||
+                "amd64".equals(arch);
+    }
+    public static boolean isPPC() {
+        String arch = getArch().toLowerCase().trim();
+        return "ppc".equals(arch) ||
+                "ppc64".equals(arch);
+    }
 
     static final String embeddedLibraryResourceRoot = "org/bridj/lib/";
     static Collection<String> getEmbeddedLibraryResource(String name) {


### PR DESCRIPTION
Ubuntu 11.04 is placing some libs, like `libX11.so` in `/usr/lib/i386-linux-gnu` or `/usr/lib/x86_64-linux-gnu` depending on a platform so BridJ cannot find them.

I've ported a fix for that from JNA. I hope it's ok in terms of licensing because I don't think there's really any other way to do this.

Original code is here https://github.com/twall/jna/pull/10
