### PR TITLE
[JNAerator] When parsing by slice,use slice.text

### DIFF
--- a/libraries/jnaerator/jnaerator/src/main/java/com/ochafik/lang/jnaerator/JNAeratorParser.java
+++ b/libraries/jnaerator/jnaerator/src/main/java/com/ochafik/lang/jnaerator/JNAeratorParser.java
@@ -208,7 +208,7 @@ public class JNAeratorParser {
 			boolean firstFailure = true;
 			for (Slice slice : slices) {
 				try {
-					sourceFiles.add(executor.submit(createParsingCallable(config, typeConverter, sourceContent, topLevelTypeDefs, false)).get(config.sliceParsingTimeout, TimeUnit.MILLISECONDS));
+					sourceFiles.add(executor.submit(createParsingCallable(config, typeConverter, slice.text, topLevelTypeDefs, false)).get(config.sliceParsingTimeout, TimeUnit.MILLISECONDS));
 				} catch (Throwable ex) {
 					if (firstFailure) {
 						WriteText.writeText(slice.text, new File("splitParsing.firstFailure.source.txt"));


### PR DESCRIPTION
When parsing by slice, must consider each slice.text individually, not the entire sourceContent repeatedly.

The slice parser was trying to consume the entire sourceContent for each slice, rather than just the slice.text.  This is apparently the reason why it was choking (issue #236) on the cec library that I am trying to wrap using JNAerator.

See also commit 4b63f0b3978f420be81eabbd2e3dbafb6cd67234 on Jan 11, 2012.
