### PR TITLE
fix: jnaerator/bridj not passing type to pointerToAddress when using callbacks

### DIFF
--- a/libraries/jnaerator/jnaerator/src/main/java/com/ochafik/lang/jnaerator/BridJDeclarationsConverter.java
+++ b/libraries/jnaerator/jnaerator/src/main/java/com/ochafik/lang/jnaerator/BridJDeclarationsConverter.java
@@ -325,7 +325,7 @@ public class BridJDeclarationsConverter extends DeclarationsConverter {
                                     followedCall = new New(nativeMethod.getValueType(), followedCall);
                                 else {
                                     Expression ptrExpr = expr(typeRef(org.bridj.Pointer.class));
-                                    if (returnType.targetTypeConversion == null || returnType.targetTypeConversion.type == ConvType.Void)
+                                    if (returnType.type != ConvType.Pointer || Arrays.asList("org.bridj.Pointer<? >").contains(String.valueOf(returnType.getTypeRef(false))))
                                         followedCall = methodCall(ptrExpr, "pointerToAddress", followedCall);
                                     else
                                         followedCall = methodCall(ptrExpr, "pointerToAddress", followedCall, result.typeConverter.typeLiteral(getSingleTypeParameter(nativeMethod.getValueType())));


### PR DESCRIPTION
Not sure how it can be improved (some string based test for now) or whether it has side effects on other cases.

The problem is illustrated in this manually fixed example:
  https://github.com/twitwi/Python27BridjWrapper/commit/1bdb59a7d2f54db29aa9730da4644ff3513b6ec1

with a cleaner manual fix (actually corresponding to the fix of the pull request):
 https://github.com/twitwi/Python27BridjWrapper/commit/fc7f83c24b3de691d607b0919e483858e740b2cb
