### PR TITLE
Stack trace from exception not being printed in debug mode

### DIFF
--- a/libraries/BridJ/src/main/java/org/bridj/BridJ.java
+++ b/libraries/BridJ/src/main/java/org/bridj/BridJ.java
@@ -776,7 +776,7 @@ public class BridJ {
                 return nativeLibraryFile;
             }
         } catch (Throwable th) {
-            warning("Library not found : " + libraryName);
+			warning("Library not found : " + libraryName, debug ? th : null);
             return null;
         }
     }
@@ -1052,7 +1052,7 @@ public class BridJ {
 	 * An example is JNA-style structures.
 	 */
 	public static <T extends NativeObject> T readFromNative(T instance) {
-		((TypeInfo<T>)instance.typeInfo).readFromNative(instance);
+		((TypeInfo<T>) instance.typeInfo).readFromNative(instance);
 		return instance;
 	}
 	/**


### PR DESCRIPTION
Hi @ochafik,

One of the Webcam Capture users recently reported problem https://github.com/sarxos/webcam-capture/issues/113 which I was unable to resolve because information available in the log was not enough to find what was the error. The problem was the fact that BridJ was either not able to find extracted *.so object or to extract it (not sure which one). After some debugging session performed by the user, he found that some configuration was wrong (I do not have any details yet), however I believe that we could possibly track it much faster if we only have enough info in the log.

Interesting log fragment obtained with `-Dbridj.veryVerbose=true`,  `-Dbridj.debug=true`:

```
INFO: Looking for library 'OpenIMAJGrabber' in paths [null, ., /usr/lib/jvm/java-7-openjdk/jre/lib/amd64/server, /usr/lib/jvm/java-7-openjdk/jre/lib/amd64, /usr/lib/jvm/java-7-openjdk/jre/../lib/amd64, /usr/lib/jvm/java-6-openjdk/jre/lib/amd64/server, /usr/lib/jvm/java-6-openjdk/jre/lib/amd64, /usr/lib/jvm/java-6-openjdk/jre/../lib/amd64, /home/jimmy/bin, /usr/lib/lightdm/lightdm, /usr/local/sbin, /usr/local/bin, /usr/sbin, /usr/bin, /sbin, /bin, /usr/games, true, /usr/lib/jvm/jdk1.6.0_33/bin, /usr/share/ant, /usr/lib/jvm/java-7-openjdk/jre/lib/amd64/server, /usr/lib/jvm/java-7-openjdk/jre/lib/amd64, /usr/lib/jvm/java-7-openjdk/jre/../lib/amd64, /usr/lib/jvm/java-6-openjdk/jre/lib/amd64/server, /usr/lib/jvm/java-6-openjdk/jre/lib/amd64, /usr/lib/jvm/java-6-openjdk/jre/../lib/amd64, /usr/java/packages/lib/amd64, /usr/lib/jni, /lib, /usr/lib, /usr/lib/jvm/java-7-openjdk/jre/lib/amd64, /usr/lib/jvm/java-7-openjdk/jre/bin, /lib/x86_64-linux-gnu, /usr/lib/x86_64-linux-gnu, /usr/lib64, /lib64, /usr/lib, /lib, /usr/local/lib]
Jun 20, 2013 6:36:12 PM org.bridj.BridJ log
INFO: Embedded paths for library OpenIMAJGrabber : [com/github/sarxos/webcam/ds/buildin/lib/linux_x64/libOpenIMAJGrabber.so, com/github/sarxos/webcam/ds/buildin/lib/linux_x64/OpenIMAJGrabber.so, org/bridj/v0_7_0/lib/linux_x64/libOpenIMAJGrabber.so, org/bridj/v0_7_0/lib/linux_x64/OpenIMAJGrabber.so, org/bridj/lib/linux_x64/libOpenIMAJGrabber.so, org/bridj/lib/linux_x64/OpenIMAJGrabber.so, lib/linux_x64/libOpenIMAJGrabber.so, lib/linux_x64/OpenIMAJGrabber.so, libs/linux_x64/libOpenIMAJGrabber.so, libs/linux_x64/OpenIMAJGrabber.so]
Jun 20, 2013 6:36:12 PM org.bridj.BridJ log
INFO: Library not found : OpenIMAJGrabber
```

But if you take a look in the code, you notice that **_Library not found : OpenIMAJGrabber_** is being printed if and only if exception has been thrown. Therefore, is logical to assume that if we have this exception printed, we could possibly track root cause much faster.

This commit is to print exception when BridJ is in debug mode.
