### PR TITLE
JNAerator: Generate Android-friendly code for direct mapping

### DIFF
--- a/libraries/jnaerator/jnaerator/src/main/java/com/ochafik/lang/jnaerator/JNADeclarationsConverter.java
+++ b/libraries/jnaerator/jnaerator/src/main/java/com/ochafik/lang/jnaerator/JNADeclarationsConverter.java
@@ -1076,6 +1076,7 @@ public class JNADeclarationsConverter extends DeclarationsConverter {
                             expr(typeRef(Native.class)),
                             Expression.MemberRefStyle.Dot,
                             "register",
+                            memberRef(expr(libTypeRef.clone()), MemberRefStyle.Dot, ident("class")),
                             libraryNameFieldExpr.clone())))).addModifiers(ModifierType.Static));
                 } else {
                     Expression[] loadLibArgs = isJNAerator


### PR DESCRIPTION
When used for JNA direct method mapping (`-direct`), JNAerator generates code like

``` java
public class FooLibrary implements StdCallLibrary {
    public static final String JNA_LIBRARY_NAME = "foo";
    public static final NativeLibrary JNA_NATIVE_LIB = NativeLibrary.getInstance(FooLibrary.JNA_LIBRARY_NAME);
    static {
        Native.register(FooLibrary.JNA_LIBRARY_NAME);
    }
```

As described in twall/jna#218, this does not work on Android. To avoid that, it should generate code like

``` java
public class FooLibrary implements StdCallLibrary {
    public static final String JNA_LIBRARY_NAME = "foo";
    public static final NativeLibrary JNA_NATIVE_LIB = NativeLibrary.getInstance(FooLibrary.JNA_LIBRARY_NAME);
    static {
        Native.register(FooLibrary.class, FooLibrary.JNA_NATIVE_LIB);
    }
```

This is implemented by the attached commit and works on both JNA 4.0 and 3.x (tested with 4.0 on Android and 3.4 on Windows).

Even better (closer to recommended usage) would be

``` java
public class FooLibrary implements StdCallLibrary {
    public static final String JNA_LIBRARY_NAME = "foo";
    public static final NativeLibrary JNA_NATIVE_LIB = NativeLibrary.getInstance(FooLibrary.JNA_LIBRARY_NAME);
    static {
        Native.register(FooLibrary.class, FooLibrary.JNA_LIBRARY_NAME);
    }
```

but that would only work with JNA 4.0, not 3.x, as the register method with that signature was only added in the fix for twall/jna#218.

I have made no attempt to actually understand the code that I’m modifying here, so it may be that I missed some `.clone()` or something, but it appears to work.
