### PR TITLE
use tiled matrices for faster matrix multiplication

### DIFF
--- a/libraries/OpenCL/Blas/src/main/java/com/nativelibs4java/opencl/blas/CLMatrix2D.java
+++ b/libraries/OpenCL/Blas/src/main/java/com/nativelibs4java/opencl/blas/CLMatrix2D.java
@@ -15,6 +15,9 @@ import org.bridj.Pointer;
  * @author ochafik
  */
 public interface CLMatrix2D<T> {
+
+    int BLOCK_SIZE = 16;
+
     Primitive getPrimitive();
     Class<T> getPrimitiveClass();
     CLEvents getEvents();

--- a/libraries/OpenCL/Blas/src/main/java/com/nativelibs4java/opencl/blas/ujmp/CLDenseMatrix2DImpl.java
+++ b/libraries/OpenCL/Blas/src/main/java/com/nativelibs4java/opencl/blas/ujmp/CLDenseMatrix2DImpl.java
@@ -5,26 +5,24 @@
 
 package com.nativelibs4java.opencl.blas.ujmp;
 
-import com.nativelibs4java.opencl.blas.CLMatrix2D;
+import com.nativelibs4java.opencl.CLBuildException;
+import com.nativelibs4java.opencl.CLEvent;
+import com.nativelibs4java.opencl.CLQueue;
 import com.nativelibs4java.opencl.blas.CLEvents;
-import com.nativelibs4java.opencl.blas.CLMatrixUtils;
 import com.nativelibs4java.opencl.blas.CLKernels;
-import org.bridj.Pointer;
-import static org.bridj.Pointer.*;
-
-import org.ujmp.core.Matrix;
-
-import org.ujmp.core.calculation.Calculation.Ret;
-import org.ujmp.core.exceptions.MatrixException;
-import com.nativelibs4java.opencl.*;
+import com.nativelibs4java.opencl.blas.CLMatrix2D;
+import com.nativelibs4java.opencl.blas.CLMatrixUtils;
 import com.nativelibs4java.opencl.util.Fun1;
 import com.nativelibs4java.opencl.util.Fun2;
-import com.nativelibs4java.opencl.util.OpenCLType;
-import com.nativelibs4java.opencl.util.Primitive;
 import com.nativelibs4java.opencl.util.ReductionUtils;
 import com.nativelibs4java.opencl.util.ReductionUtils.Reductor;
-import org.ujmp.core.doublematrix.DoubleMatrix2D;
+
+import org.bridj.Pointer;
+import org.ujmp.core.calculation.Calculation.Ret;
+import org.ujmp.core.exceptions.MatrixException;
 import org.ujmp.core.matrix.Matrix2D;
+
+import static org.bridj.Pointer.allocate;
 
 /**
  *
@@ -36,7 +34,7 @@ public class CLDenseMatrix2DImpl<V> {
     protected Pointer<V> cache;
     protected int uncachedGetCount;
     protected static final int GET_COUNT_BEFORE_CACHING = 3;
-    
+
     public CLDenseMatrix2DImpl(CLMatrix2D<V> _matrix) {
         this._matrix = _matrix;
         this.rows = _matrix.getRowCount();
@@ -59,7 +57,7 @@ public class CLDenseMatrix2DImpl<V> {
     }
     
     protected long getStorageIndex(long row, long column) {
-        return row * columns + column;
+        return CLMatrixUtils.roundUp(columns) * row + column;
     }
 
     protected synchronized void cache() {

--- a/libraries/OpenCL/Blas/src/main/java/com/nativelibs4java/opencl/blas/ujmp/CLWrappedMatrix2D.java
+++ b/libraries/OpenCL/Blas/src/main/java/com/nativelibs4java/opencl/blas/ujmp/CLWrappedMatrix2D.java
@@ -4,21 +4,23 @@
  */
 package com.nativelibs4java.opencl.blas.ujmp;
 
-import com.nativelibs4java.opencl.blas.CLMatrix2D;
-import com.nativelibs4java.opencl.blas.CLEvents;
-import com.nativelibs4java.opencl.blas.CLMatrixUtils;
-import com.nativelibs4java.opencl.blas.CLKernels;
 import com.nativelibs4java.opencl.CLBuffer;
 import com.nativelibs4java.opencl.CLContext;
 import com.nativelibs4java.opencl.CLEvent;
 import com.nativelibs4java.opencl.CLMem.Usage;
 import com.nativelibs4java.opencl.CLQueue;
+import com.nativelibs4java.opencl.blas.CLEvents;
+import com.nativelibs4java.opencl.blas.CLKernels;
+import com.nativelibs4java.opencl.blas.CLMatrix2D;
+import com.nativelibs4java.opencl.blas.CLMatrixUtils;
 import com.nativelibs4java.opencl.util.Primitive;
+
 import org.bridj.Pointer;
-import static org.bridj.Pointer.*;
 import org.ujmp.core.doublematrix.DoubleMatrix2D;
 import org.ujmp.core.floatmatrix.FloatMatrix2D;
 import org.ujmp.core.matrix.Matrix2D;
+
+import static org.bridj.Pointer.allocateArray;
 
 /**
  *
@@ -68,16 +70,18 @@ public class CLWrappedMatrix2D<T> implements CLMatrix2D<T> {
     volatile CLBuffer<T> buffer;
     volatile Pointer data;
     public synchronized CLBuffer<T> getBuffer() {
-        long length = matrix.getRowCount() * matrix.getColumnCount();
+        long length = CLMatrixUtils.roundUp(matrix.getRowCount()) * CLMatrixUtils.roundUp(matrix.getColumnCount());
 
         // Read data
-        if (data == null)
+        if (data == null) {
             data = allocateArray(elementType, length).order(getContext().getByteOrder());
+        }
         MatrixUtils.read(matrix, data);
 
         // Write data to CLBuffer
-        if (buffer == null)
+        if (buffer == null) {
             buffer = kernels.getContext().createBuffer(Usage.Input, elementType, length);
+        }
 
         events.performWrite(new CLEvents.Action() {
             public CLEvent perform(CLEvent[] events) {

--- a/libraries/OpenCL/pom.xml
+++ b/libraries/OpenCL/pom.xml
@@ -25,9 +25,7 @@
 		<module>Demos</module>
 		<module>JavaCL</module>
 		<module>Core</module>
-		<!-- Blas requires ujmp, which is not in Maven Central:
 		<module>Blas</module>
-		-->
 		<module>OpenGLDemos</module>
 		<module>Tutorials</module>
 	</modules>


### PR DESCRIPTION
The matrix multiplication implementation was quite naive.  There are well-known improvements to be made such as read/write coalescing & tiling.  These are implemented in a couple of code samples available on the web, such as
  http://www.shodor.org/media/content//petascale/materials/UPModules/matrixMultiplication/moduleDocument.pdf
and
  https://developer.nvidia.com/opencl

In this patch, I've adjusted the NVidia implementation of the kernel.  Haven't run systematic benchmarks yet, but sample matrix multiplications with 10M multiply-add operations go from 17.5mus to 0.66mus (25x speedup).

The block size is 16, same as in the above references.  All matrices are expanded to multiples of this, so there is some overhead on the blas facade.  Some current limitations:
- the containsValue method only works for matrices of commensurate dimensions
- matrices with non-commensurate sizes need to be cleared before they can be used

These limitations are obvious candidates for further improvement; another improvement that I would like to look into is to use similar techniques for the transpose kernel.
