### PR TITLE
Fix issue #459 in JNAerator: parse exotic enums.

### DIFF
--- a/libraries/jnaerator/jnaerator-parser/src/main/antlr3/com/ochafik/lang/jnaerator/parser/ObjCpp.g
+++ b/libraries/jnaerator/jnaerator-parser/src/main/antlr3/com/ochafik/lang/jnaerator/parser/ObjCpp.g
@@ -674,6 +674,7 @@ enumCore returns [Enum e]
     (
       ( m1=modifiers { modifiers.addAll($m1.modifiers); } )?
       (
+      	( ':' IDENTIFIER )?
         ab=enumBody {
           $e = $ab.e;
           $e.setForwardDeclaration(false);
@@ -681,6 +682,7 @@ enumCore returns [Enum e]
         tag=qualifiedIdentifier
         (
           ( m2=modifiers { modifiers.addAll($m2.modifiers); } )?
+          ( ':' IDENTIFIER )?
           nb=enumBody {
             $e = $nb.e;
             $e.setForwardDeclaration(false);

--- a/libraries/jnaerator/jnaerator/src/test/resources/com/ochafik/lang/jnaerator/parser/ObjCppTest.mm
+++ b/libraries/jnaerator/jnaerator/src/test/resources/com/ochafik/lang/jnaerator/parser/ObjCppTest.mm
@@ -537,3 +537,5 @@ class fpos
 {
 	fpos() {}
 };
+--
+typedef enum : Foo { Quux } Baz;


### PR DESCRIPTION
Note: this fix does not retain the type behind : in the AST, it just
fixes the infinite loop issue in the parser.
