### PR TITLE
Fix string index oob in octal escapes

### DIFF
--- a/libraries/jnaerator/jnaerator-parser/src/main/java/com/ochafik/lang/jnaerator/parser/Expression.java
+++ b/libraries/jnaerator/jnaerator-parser/src/main/java/com/ochafik/lang/jnaerator/parser/Expression.java
@@ -1304,7 +1304,7 @@ public abstract class Expression extends Element {
 						if (Character.isDigit(c)) {
 							int start = i - 1;
 							int end = i;
-							while (Character.isDigit(string.charAt(end))) {
+							while (end < len && Character.isDigit(string.charAt(end))) {
 								end++;
 							}
 							b.append((char)Integer.parseInt(string.substring(start, end), 8));


### PR DESCRIPTION
Check for the end of string
fixes glib gscanner.h's G_CSET_LATINS and G_CSET_LATINC

https://github.com/codeanticode/gstreamer-1.x-java/issues/1
