### PR TITLE
When determining if two methods in a class extending Callback are equiva...

### DIFF
--- a/libraries/BridJ/src/main/java/org/bridj/CRuntime.java
+++ b/libraries/BridJ/src/main/java/org/bridj/CRuntime.java
@@ -650,7 +650,9 @@ public class CRuntime extends AbstractBridJRuntime {
     private static boolean sameBindings(Class t1, Class t2) {
         return t1.equals(t2) ||
             t1 == long.class && Pointer.class.isAssignableFrom(t2) ||
-            t2 == long.class && Pointer.class.isAssignableFrom(t1);
+            t2 == long.class && Pointer.class.isAssignableFrom(t1) ||
+            t1 == int.class && IntValuedEnum.class.isAssignableFrom(t2) ||
+            t2 == int.class && IntValuedEnum.class.isAssignableFrom(t1);
     }
     
     public <T extends NativeObject> Class<? extends T> getTypeForCast(Type type) {


### PR DESCRIPTION
...lent, add an exception for int == IntValuedEnum parameters like there is for long == Pointer. This fixes runtime callback resolution failures against jnaerator-ed code (with raw bindings enabled).
