### PR TITLE
Update BridJ.java (typo mscvrt)

### DIFF
--- a/libraries/BridJ/src/main/java/org/bridj/BridJ.java
+++ b/libraries/BridJ/src/main/java/org/bridj/BridJ.java
@@ -1049,7 +1049,7 @@ public class BridJ {
             if (ll == null) {
                 boolean isWindows = Platform.isWindows();
                 if ("c".equals(name) || "m".equals(name) && isWindows) {
-                    ll = new NativeLibrary(isWindows ? "mscvrt" : null, 0, 0);
+                    ll = new NativeLibrary(isWindows ? "msvcrt" : null, 0, 0);
                 }
             }
         }


### PR DESCRIPTION
Fixed typo for windows c library alias: "mscvrt" should read "msvcrt".
