### PR TITLE
Raw mode: native methods are missing actual name

### DIFF
--- a/libraries/jnaerator/jnaerator/src/main/java/com/ochafik/lang/jnaerator/BridJDeclarationsConverter.java
+++ b/libraries/jnaerator/jnaerator/src/main/java/com/ochafik/lang/jnaerator/BridJDeclarationsConverter.java
@@ -392,6 +392,10 @@ public class BridJDeclarationsConverter extends DeclarationsConverter {
                             rawMethod.removeModifiers(ModifierType.Abstract);
                             rawMethod.setBody(block(new Statement.Return(rawToObjectFollowedCall)));
                         }
+                        else if (function.getName() != null && !function.getName().equals(rawMethod.getName()))
+                        {
+                        	annotateActualName(rawMethod, function.getName());
+                        }
                     }
                     forwardedToRaw = true;
                 }


### PR DESCRIPTION
Raw bindings mode is producing the following Java code when a native
method’s return type is a pointer:

public static Pointer&lt;Foo &gt; foo() {
return Pointer.pointerToAddress(foo$2(), Foo.class);
}
@Ptr
protected native static long foo$2();

The problem is that foo$2 will not resolve to the actual underlying
native method ‘foo’, resulting in warnings like:

INFO: Failed to get address of method protected static native long
MyClass.foo$2()

This change will cause a @Name annotation to be added to the raw
binding method as necessary, so the above generates as

@Ptr
@Name(“foo”)
protected native static long foo$2();
