### PR TITLE
Issue #559 get library paths

### DIFF
--- a/libraries/BridJ/src/main/java/org/bridj/BridJ.java
+++ b/libraries/BridJ/src/main/java/org/bridj/BridJ.java
@@ -31,11 +31,15 @@
 package org.bridj;
 
 import org.bridj.ann.Forwardable;
+
 import java.util.Set;
 import java.util.HashSet;
+
 import org.bridj.util.Utils;
+
 import static org.bridj.util.AnnotationUtils.*;
 import static org.bridj.util.Utils.*;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -59,13 +63,17 @@ import org.bridj.BridJRuntime.TypeInfo;
 import org.bridj.demangling.Demangler.Symbol;
 import org.bridj.demangling.Demangler.MemberRef;
 import org.bridj.ann.Library;
+
 import java.util.Stack;
 import java.io.PrintWriter;
 import java.lang.reflect.Type;
 import java.net.URL;
+
 import org.bridj.util.StringUtils;
+
 import static org.bridj.Platform.*;
 import static java.lang.System.*;
+
 import org.bridj.util.ClassDefiner;
 import org.bridj.util.ASMUtils;
 
@@ -734,9 +742,11 @@ public class BridJ {
                 nativeLibraryPaths.add("/usr/local/lib");
             }
             for (Iterator<String> it = nativeLibraryPaths.iterator(); it.hasNext();) {
-              if (!new File(it.next()).isDirectory()) {
+                final String next = it.next();
+                if (null != next && new File(next).isDirectory()) {
+                    continue;
+                }
                 it.remove();
-              }
             }
         }
         return nativeLibraryPaths;

--- a/libraries/BridJ/src/main/velocity/org/bridj/Pointer.java
+++ b/libraries/BridJ/src/main/velocity/org/bridj/Pointer.java
@@ -2438,7 +2438,7 @@ public abstract class Pointer<T> implements Comparable<Pointer<?>>, Iterable<T>
 		if (values == null)
 			return null;
 		int n = values.length, s = Pointer.SIZE;
-		PointerIO<Pointer> pio = PointerIO.getPointerInstance(); // TODO get actual pointer instances PointerIO !!!
+		PointerIO<?> pio = PointerIO.getPointerInstance(); // TODO get actual pointer instances PointerIO !!!
 		Pointer<Pointer<T>> p = (Pointer<Pointer<T>>)(Pointer)allocateArray(pio, n);
 		for (int i = 0; i < n; i++) {
 			p.setPointerAtOffset(i * s, values[i]);

--- a/libraries/BridJ/src/main/velocity/org/bridj/PointerIO.java
+++ b/libraries/BridJ/src/main/velocity/org/bridj/PointerIO.java
@@ -97,7 +97,7 @@ public abstract class PointerIO<T> {
 		return null;
 	}
 	
-	private static final PointerIO<Pointer> PointerIO = getPointerInstance((PointerIO)null);
+	private static final PointerIO<?> PointerIO = getPointerInstance((PointerIO<?>)null);
 
 	public static <T> PointerIO<Pointer<T>> getPointerInstance(Type target) {
 		return getPointerInstance((PointerIO<T>)getInstance(target));
@@ -185,7 +185,7 @@ public abstract class PointerIO<T> {
   	}
   	#end #end
 
-  	public static PointerIO<Pointer> getPointerInstance() {
+  	public static PointerIO<?> getPointerInstance() {
       return PointerIO;
   	}
 


### PR DESCRIPTION
In Eclipse, the NPE was masked by falling back to class loader resource access.
